### PR TITLE
Autocorrect forwarded ports if collision

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,11 +14,11 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = "kohadevbox"
   config.vm.box = "chef/debian-7.6"
 
-  config.vm.network :forwarded_port, guest: 6001, host: 6001  # SIP2
-  config.vm.network :forwarded_port, guest: 80,   host: 8080  # OPAC
-  config.vm.network :forwarded_port, guest: 8080, host: 8081  # INTRA
-  config.vm.network :forwarded_port, guest: 5000, host: 5000  # Plack OPAC
-  config.vm.network :forwarded_port, guest: 5001, host: 5001  # Plack INTRA
+  config.vm.network :forwarded_port, guest: 6001, host: 6001, auto_correct: true  # SIP2
+  config.vm.network :forwarded_port, guest: 80,   host: 8080, auto_correct: true  # OPAC
+  config.vm.network :forwarded_port, guest: 8080, host: 8081, auto_correct: true  # INTRA
+  config.vm.network :forwarded_port, guest: 5000, host: 5000, auto_correct: true  # Plack OPAC
+  config.vm.network :forwarded_port, guest: 5001, host: 5001, auto_correct: true  # Plack INTRA
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", "768"]


### PR DESCRIPTION
If ports are already in use (e.g. 8080, 8081) on host, auto_correct will choose other available ports. Otherwise box will fail
