### PR TITLE
 Add git aliases for git qa and git qa-tidy

### DIFF
--- a/setup-koha.sh
+++ b/setup-koha.sh
@@ -109,6 +109,10 @@ git config --global color.diff auto
 git config --global diff.tool vimdiff
 git config --global difftool.prompt false
 git config --global alias.d difftool
+# Allows usage like git qa <bugnumber> to set up a branch based on master and fetch patches for <bugnumber> from bugzilla
+git config --global alias.qa '!sh -c "git fetch origin master && git rebase origin/master && git checkout -b qa-$1 origin/master && git bz apply $1"' -
+# Allows usage like git qa-tidy <bugnumber> to remove a qa branch when you are through with it
+git config --global alias.qa-tidy '!sh -c "git checkout master && git branch -D qa-$1"' -
 git config --global core.whitespace trailing-space,space-before-tab
 git config --global apply.whitespace fix
 


### PR DESCRIPTION
Adding default git aliases for git qa and git qa-tidy
Example usage:
git qa 12344
git qa-tidy 12344

What they do:
git qa bugnumber
Checks out master
Fetches origin/master
rebases origin/master
Checks out a branch: qa-bugnumber based on master
Fetches the patches from bug bugnumber from bugzilla and attempts to apply them.

git qa-tidy bugnumber
checks out master
deletes the qa branch associated with bugnumber
