### PR TITLE
Add https to OPAC

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.network :forwarded_port, guest: 6001, host: 6001, auto_correct: true  # SIP2
   config.vm.network :forwarded_port, guest: 80,   host: 8080, auto_correct: true  # OPAC
+  config.vm.network :forwarded_port, guest: 443,  host: 443,  auto_correct: true  # OPAC https
   config.vm.network :forwarded_port, guest: 8080, host: 8081, auto_correct: true  # INTRA
   config.vm.network :forwarded_port, guest: 5000, host: 5000, auto_correct: true  # Plack OPAC
   config.vm.network :forwarded_port, guest: 5001, host: 5001, auto_correct: true  # Plack INTRA

--- a/insert_https.pl
+++ b/insert_https.pl
@@ -1,0 +1,79 @@
+#!/usr/bin/perl -Tw
+
+use strict;
+use warnings;
+use File::Copy;
+
+# Read the file.
+open my $rfh,"<","/etc/apache2/sites-available/kohadev.conf" || die "Unable to read kohadev.conf apache configuration file!\n";
+my @data = <$rfh>;
+close $rfh;
+
+# find the OPAC block create a copy
+my @opacblock;
+my $flag=0;
+
+foreach my $line (@data) {
+    if ($flag==0) {
+        if ($line =~ /^#\s*OPAC\s*$/) {
+            $flag = 1;
+        }
+        if ($flag) {
+            push @opacblock,$line;
+        }
+    }
+    else {
+        if ($line =~ /^#\s*Intranet\s*$/) {
+            $flag = 0;
+        }
+        if ($flag) {
+            push @opacblock,$line;
+        }
+    }
+}
+
+# add the SSL lines in;
+my @SSLopacblock;
+foreach my $line (@opacblock) {
+
+    # just after the AssignUserID line
+    if ($line =~ /^\s*AssignUserID\s.*$/) {
+        push @SSLopacblock,$line;
+        push @SSLopacblock,"\n";
+        push @SSLopacblock,"   SSLEngine on\n";
+        push @SSLopacblock,"   SSLCertificateFile    /etc/ssl/certs/ssl-cert-snakeoil.pem\n";
+        push @SSLopacblock,"   SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key\n";
+    }
+    # making sure to tweak the port number
+    elsif ($line =~ /^<VirtualHost \*:80>/) {
+        $line =~ s/80/443/g;
+        push @SSLopacblock,$line;
+    }
+    else {
+        push @SSLopacblock,$line;
+    }
+}
+
+#build full revised data set with the added SSL block
+my @reviseddata;
+foreach my $line (@data) {
+    if ($line =~ /^#\s*OPAC\s*$/) {
+        push @reviseddata,@SSLopacblock;
+    }
+    push @reviseddata,$line;
+}
+
+# copy out the original config file.
+open my $cfh,">","/etc/apache2/sites-available/kohadev.conf.nossl" || die "Unable to write kohadev.conf.nossl apache configuration file!\n";
+print $cfh @data;
+close $cfh;
+
+# write out the revised config file.
+open my $wfh,">","/etc/apache2/sites-available/kohadev.conf.ssl" || die "Unable to write kohadev.conf.ssl apache configuration file!\n";
+print $wfh @reviseddata;
+close $wfh;
+
+# overwrite the existing config file.
+open my $nfh,">","/etc/apache2/sites-available/kohadev.conf" || die "Unable to write kohadev.conf apache configuration file!\n";
+print $nfh @reviseddata;
+close $nfh;

--- a/setup-koha.sh
+++ b/setup-koha.sh
@@ -42,6 +42,7 @@ sudo apt-get install -q -y libtest-file-perl
 
 # Configure Apache
 sudo a2enmod rewrite
+sudo a2enmod ssl
 sudo a2dissite default
 echo "Listen 8080" | sudo tee --append "/etc/apache2/ports.conf"
 sudo service apache2 restart
@@ -122,6 +123,10 @@ cd
 git clone https://github.com/mkfifo/koha-gitify.git gitify
 cd gitify
 sudo ./koha-gitify "$instance_name" $KOHACLONE
+sudo service apache2 restart
+
+# Add SSL to OPAC configuration
+sudo /vagrant/insert_https.pl
 sudo service apache2 restart
 
 # Git bz


### PR DESCRIPTION
This adds https to OPAC, while keeping http as well. It does
this by merely mirroring the https site from the http site.
The certificates used are the defaults, and you will get a
security warning about them. One can tweak the SSL configuration
further, if they so desire.