### PR TITLE
Remove Test::CGI::Multipart from the dep list

### DIFF
--- a/roles/kohadevbox/tasks/koha.yml
+++ b/roles/kohadevbox/tasks/koha.yml
@@ -1,8 +1,3 @@
-- name: Dependencies fix for Jessie (get)
-  get_url: url=http://repo.asis.io/jessie-updates/pool/main/libt/libtest-cgi-multipart-perl/libtest-cgi-multipart-perl_0.0.3-1_all.deb
-           dest=/tmp/libtest-cgi-multipart-perl_0.0.3-1_all.deb mode=0644
-  when: ansible_distribution_release == 'jessie'
-
 - name: Dependencies fix for Jessie (deps)
   apt:  pkg={{ item }} state=latest
   with_items:
@@ -10,10 +5,6 @@
     - libuniversal-require-perl
     - libreadonly-perl
     - libparams-validate-perl
-
-- name: Dependencies fix for Jessie (install)
-  shell: dpkg -i /tmp/libtest-cgi-multipart-perl_0.0.3-1_all.deb
-  when: ansible_distribution_release == 'jessie'
 
 - name: Install Koha
   apt: pkg=koha-common state=latest force=yes


### PR DESCRIPTION
`vagrant up jessie` fails because repo.asis.io is not reachable.
Anyway, Test::CGI::Multipart is not a Koha dep anymore.