### PR TITLE
Fix commit author (email vs name)

### DIFF
--- a/roles/kohadevbox/templates/gitconfig.j2
+++ b/roles/kohadevbox/templates/gitconfig.j2
@@ -1,6 +1,6 @@
 [user]
-    name = {{ git_email }}
-    email = {{ git_full_name }}
+    name = {{ git_full_name }}
+    email = {{ git_email }}
 
 [bz]
     default-tracker = bugs.koha-community.org


### PR DESCRIPTION
The email is used for the name and the reverse.