### PR TITLE
Fix vagrant base box reference chef -> bento

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.hostname = "kohadevbox"
-  config.vm.box = "chef/debian-7.8"
+  config.vm.box = "bento/debian-7.8"
 
   config.vm.network :forwarded_port, guest: 6001, host: 6001, auto_correct: true  # SIP2
   config.vm.network :forwarded_port, guest: 80,   host: 8080, auto_correct: true  # OPAC


### PR DESCRIPTION
Fix for issue #71 while longer term replacement  is deliberated. Bento is the new name for Chef's base images source, so this is essentially a one to one replacement that unbreaks the project until a different replacement is chosen.