### PR TITLE
Add minimum ansible version to site.yml

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,8 @@
 # vi: set ft=ruby :
 require 'fileutils' 
 
+Vagrant.require_version ">= 1.8.1"
+
 Vagrant.configure(2) do |config|
 
   # http://fgrehm.viewdocs.io/vagrant-cachier

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,7 @@
 # This is the top-level playbook for deploying Bokeh at UNC
 
 - hosts: all
+  ansible_required: 1.9
   user: vagrant
   become: True
   become_user: root


### PR DESCRIPTION
Addresses Issue #90 -- 'ansible: ERROR: become is not a legal parameter in an Ansible
Playbook', by requiring that the ansible version must be at least 1.9.