### PR TITLE
Issue #117: Do not fail provisioning if koha-plack commands fail

### DIFF
--- a/roles/kohadevbox/tasks/plack.yml
+++ b/roles/kohadevbox/tasks/plack.yml
@@ -1,7 +1,9 @@
 # Tasks required for setting Plack
 - name: Enable Plack
-  command: koha-plack --enable {{ koha_instance_name }}
+  command: koha-plack --enable {{ koha_instance_name }} > /dev/null 2>&1 || /bin/true
+  ignore_errors: yes
 
 - name: Start Plack
-  shell:  koha-plack --start {{ koha_instance_name }}
+  shell:  koha-plack --start {{ koha_instance_name }} > /dev/null 2>&1 || /bin/true
   notify: restart apache
+  ignore_errors: yes


### PR DESCRIPTION
koha-plack --enable returns an error code (1) if plack is already enabled and so the vagrant up command fails:

TASK [kohadevbox : Enable Plack] ***********************************************
fatal: [jessie]: FAILED! => {"changed": true, "cmd": ["koha-plack", "--enable", "kohadev"], "delta": "0:00:00.118633", "end": "2016-10-27 11:23:20.287461", "failed": true, "rc": 1, "start": "2016-10-27 11:23:20.168828", "stderr": "Plack already enabled for kohadev", "stdout": "", "stdout_lines": [], "warnings": []}