### PR TITLE
Issue #121: Make port, prefix and suffix customisable

### DIFF
--- a/roles/kohadevbox/templates/koha-sites.conf.j2
+++ b/roles/kohadevbox/templates/koha-sites.conf.j2
@@ -6,12 +6,12 @@
 # OPAC:  http://<OPACPREFIX><INSTANCE NAME><OPACSUFFIX><DOMAIN>:<OPACPORT>
 # STAFF: http://<INTRAPREFIX><INSTANCE NAME><INTRASUFFIX><DOMAIN>:<INTRAPORT>
 DOMAIN="{{ koha_domain }}"
-INTRAPORT="8080"
-INTRAPREFIX=""
-INTRASUFFIX="-intra"
-OPACPORT="80"
-OPACPREFIX=""
-OPACSUFFIX=""
+INTRAPORT="{{ koha_intra_port }}"
+INTRAPREFIX="{{ koha_intra_prefix }}"
+INTRASUFFIX="{{ koha_intra_suffix }}"
+OPACPORT="{{ koha_opac_port }}"
+OPACPREFIX="{{ koha_opac_prefix }}"
+OPACSUFFIX="{{ koha_opac_suffix }}"
 
 ## Default data to be loaded
 #

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -35,6 +35,12 @@ koha_git_branch: master
 
 koha_instance_name: kohadev
 koha_domain: .myDNSname.org
+koha_intra_port: 8080
+koha_intra_prefix: ""
+koha_intra_suffix: "-intra"
+koha_opac_port: 80
+koha_opac_prefix: ""
+koha_opac_suffix: ""
 koha_marc_flavour: marc21
 koha_zebra_language: en
 koha_db_password: password

--- a/vars/user.yml.sample
+++ b/vars/user.yml.sample
@@ -38,6 +38,12 @@
 
 # koha_instance_name: kohadev
 # koha_domain: .myDNSname.org
+# koha_intra_port: 8080
+# koha_intra_prefix: ""
+# koha_intra_suffix: "-intra"
+# koha_opac_port: 80
+# koha_opac_prefix: ""
+# koha_opac_suffix: ""
 # koha_marc_flavour: marc21
 # koha_zebra_language: en
 # koha_db_password: password


### PR DESCRIPTION
Since we are using ports to separate OPAC and staff interfaces, the
sessions are shared.
It's a bit frustrating when you need to use different users to test
something.

That could be fixed using different server names in the apache config,
like staff.kohadev.vm and opac.kohadev.vm