### PR TITLE
Issue #123: Do not install WWW::CSRF via cpan

### DIFF
--- a/roles/kohadevbox/tasks/koha.yml
+++ b/roles/kohadevbox/tasks/koha.yml
@@ -22,7 +22,6 @@
   become_user: root
   cpanm: name={{ item }}
   with_items:
-    - WWW::CSRF
     - Sereal
 
 - name: Install (temporarily) not pulled dependencies (deb)


### PR DESCRIPTION
... as it is now packaged
https://debian.koha-community.org/koha/pool/main/libw/libwww-csrf-perl/