### PR TITLE
Issue 173: Prevent failure because kohaclone directory doesn't exist

### DIFF
--- a/roles/kohadevbox/tasks/gitify.yml
+++ b/roles/kohadevbox/tasks/gitify.yml
@@ -9,3 +9,6 @@
 - name: Gitify the Koha instance
   shell:  ./koha-gitify {{ koha_instance_name }} /home/vagrant/kohaclone chdir={{ gitify_dir }}
   become_user: root
+
+- name: Replace koha-* scripts
+  shell: perl {{ misc4dev_dir }}/cp_debian_files.pl

--- a/roles/kohadevbox/tasks/koha.yml
+++ b/roles/kohadevbox/tasks/koha.yml
@@ -21,9 +21,6 @@
 - name: Install Koha
   apt: pkg=koha-common state=latest force=yes
 
-- name: Replace koha-* scripts
-  shell: perl {{ misc4dev_dir }}/cp_debian_files.pl
-
 - name: Use our koha-sites.conf file
   template: src=koha-sites.conf.j2 dest=/etc/koha/koha-sites.conf mode=0644 owner=root
 


### PR DESCRIPTION
TEST PLAN
---------
vagrant destroy jessie
vagrant up jessie
-- will fail while attempting to run misc4dev's cp_debian_files.pl
apply this patch
attempt a destroy and up again
-- the cp_debian_files.pl step will succeed