### PR TITLE
Issue 200: Stretch VM fails to come up nicely

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ to set up a VirtualBox. It targets the following tasks:
 
 * A virtual machine running either:
 
-  - Debian 8 (jessie) [*]
+  - Debian 9 (stretch)
+  - *Debian 8 (jessie) [*\**]*
   - Debian 7 (wheezy)
   - Ubuntu 16.04 (xenial)
   - Ubuntu 14.04 (trusty)
 
-[*] Default if none specified.
+*[*\**]* Default if none specified.
 
 * Latest version of koha-common from the unstable repository (master branch)
   or your custom repository if specified.
@@ -44,7 +45,7 @@ If you don't have them already, you need to install some prerequisites:
 
   **Note:** Ubuntu and Debian ship their own vagrant package, but don't use it. Download the latest version from the above URL.
 
-* Ansible (version 1.9+): http://docs.ansible.com/ansible/intro_installation.html
+* Ansible (version 2.1+): http://docs.ansible.com/ansible/intro_installation.html
   
   **Note:** Ansible is not required when installing on **Windows** or when using LOCAL_ANSIBLE=1.
 

--- a/roles/kohadevbox/meta/main.yml
+++ b/roles/kohadevbox/meta/main.yml
@@ -3,15 +3,17 @@
 galaxy_info:
   author: Magnus Enger and Tomás Cohen Arazi
   license: GPLv3
-  min_ansible_version: 1.6
+  min_ansible_version: 2.1
   platforms:
     - name: Ubuntu
       versions:
         - trusty
+        - xenial
     - name: Debian
       versions:
         - wheezy
         - jessie
+        - stretch
   categories:
      - web
 dependencies: []

--- a/roles/kohadevbox/tasks/koha.yml
+++ b/roles/kohadevbox/tasks/koha.yml
@@ -29,12 +29,12 @@
     owner: root
   when: koha_use_custom_repo and koha_pin_custom_repo
 
+- name: Install Koha | Install older JSON::Validator
+  apt:
+    deb: http://debian.koha-community.org/koha/pool/main/libj/libjson-validator-perl/libjson-validator-perl_0.67+dfsg-1~koha1_all.deb
+
 - name: Install Koha | Install koha-common
   apt:
     name: koha-common
     state: latest
     force: yes
-
-- name: Install Koha | Install older JSON::Validator
-  apt:
-    deb: http://debian.koha-community.org/koha/pool/main/libj/libjson-validator-perl/libjson-validator-perl_0.67+dfsg-1~koha1_all.deb

--- a/roles/kohadevbox/tasks/koha.yml
+++ b/roles/kohadevbox/tasks/koha.yml
@@ -38,3 +38,9 @@
     name: koha-common
     state: latest
     force: yes
+
+- name: Install Koha | Install mlocate
+  apt:
+    name: mlocate
+    state: latest
+    force: yes

--- a/roles/kohadevbox/tasks/less.yml
+++ b/roles/kohadevbox/tasks/less.yml
@@ -4,10 +4,17 @@
     url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
     state: present
 
-- name: Less | Add Node.js repository (repo)
+- name: Less | Add Node.js repository (non-stretch repo)
   apt_repository:
     repo: "deb https://deb.nodesource.com/{{ node_version }} {{ ansible_distribution_release }} main"
     state: present
+  when: (not ansible_distribution_release == "stretch")
+
+- name: Less | Add Node.js repository (stretch repo)
+  apt_repository:
+    repo: "deb https://deb.nodesource.com/{{ node_version }} jessie main"
+    state: present
+  when: ansible_distribution_release == "stretch"
 
 - name: Less | Instal Node.js
   apt:

--- a/roles/kohadevbox/tasks/qatools.yml
+++ b/roles/kohadevbox/tasks/qatools.yml
@@ -16,6 +16,8 @@
     - libtest-differences-perl
     - libdbd-sqlite2-perl
     - codespell
+    - libdbix-class-timestamp-perl
+    - libmodule-install-perl
   become: yes
 
 - name: Koha QA tools | CPAN dependencies
@@ -26,6 +28,7 @@
   with_items:
     - DBD::SQLite
     - HTTPD::Bench::ApacheBench
+    - MooseX::Attribute::ENV
     - Test::DBIx::Class
   retries: 5
   delay: 1

--- a/tools/install-ansible.sh
+++ b/tools/install-ansible.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7BB9C367
-sudo apt-get install -q -y software-properties-common
-sudo apt-add-repository -y "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main"
 sudo apt-get update -q
 sudo apt-get install -y -q ansible
+ANSIBLE_VERSION=`dpkg -s ansible | grep Version | cut -f2 -d' '`
+if [[ "$ANSIBLE_VERSION" < "1.9" ]]; then
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7BB9C367
+    sudo apt-get install -q -y software-properties-common
+    sudo apt-add-repository -y "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main"
+    sudo apt-get update -q
+    sudo apt-get install -y -q ansible
+fi

--- a/tools/install-ansible.sh
+++ b/tools/install-ansible.sh
@@ -3,7 +3,7 @@
 sudo apt-get update -q
 sudo apt-get install -y -q ansible
 ANSIBLE_VERSION=`dpkg -s ansible | grep Version | cut -f2 -d' '`
-if [[ "$ANSIBLE_VERSION" < "1.9" ]]; then
+if [[ "$ANSIBLE_VERSION" < "2.1" ]]; then
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7BB9C367
     sudo apt-get install -q -y software-properties-common
     sudo apt-add-repository -y "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main"

--- a/tools/install-ansible.sh
+++ b/tools/install-ansible.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 sudo apt-get update -q
-sudo apt-get install -y -q ansible
-ANSIBLE_VERSION=`dpkg -s ansible | grep Version | cut -f2 -d' '`
+ANSIBLE_VERSION=`apt-cache show ansible | grep Version | cut -f2 -d' '`
 if [[ "$ANSIBLE_VERSION" < "2.1" ]]; then
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7BB9C367
     sudo apt-get install -q -y software-properties-common
     sudo apt-add-repository -y "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main"
     sudo apt-get update -q
-    sudo apt-get install -y -q ansible
 fi
+sudo apt-get install -y -q ansible

--- a/tools/install-ansible.sh
+++ b/tools/install-ansible.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 sudo apt-get update -q
-ANSIBLE_VERSION=`apt-cache show ansible | grep Version | cut -f2 -d' '`
+ANSIBLE_VERSION=`apt-cache show ansible | grep Version | cut -f2 -d' ' | sort -r | head -1`
 if [[ "$ANSIBLE_VERSION" < "2.1" ]]; then
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7BB9C367
     sudo apt-get install -q -y software-properties-common
     sudo apt-add-repository -y "deb http://ppa.launchpad.net/ansible/ansible/ubuntu xenial main"
     sudo apt-get update -q
+    ANSIBLE_VERSION=`apt-cache show ansible | grep Version | cut -f2 -d' ' | sort -r | head -1`
 fi
-sudo apt-get install -y -q ansible
+sudo apt-get install -y -q ansible=$ANSIBLE_VERSION


### PR DESCRIPTION
By changing the script to attempt installing ansible from default repos,
then adding only if the version is less than 1.9, this allows stretch
to come up with ansible 2.2 which isn't 2.3 from the repo, but more than
the 1.9 which is supposedly the minimum based on the README file.

TEST PLAN
----------
vagrant destroy jessie
vagrant up jessie
vagrant destroy xenial
vagrant up xenial
vagrant destroy stretch
vagrant up stretch
-- all should come up without issue.