### PR TITLE
Issue 202: Integrate kohadocs repository and Sphinx

### DIFF
--- a/roles/kohadevbox/tasks/kohadocs-src.yml
+++ b/roles/kohadevbox/tasks/kohadocs-src.yml
@@ -1,0 +1,6 @@
+- name: Koha manual | Clone repository
+  git:
+    repo: "{{ kohadocs_git_repo }}"
+    dest: /home/vagrant/kohadocs
+    version: "{{ kohadocs_git_branch }}"
+  when: enable_kohadocs

--- a/roles/kohadevbox/tasks/main.yml
+++ b/roles/kohadevbox/tasks/main.yml
@@ -15,6 +15,8 @@
 
   - include: koha-src.yml
 
+  - include: kohadocs-src.yml
+
   - include: koha.yml
     become: yes
 

--- a/roles/kohadevbox/tasks/tools.yml
+++ b/roles/kohadevbox/tasks/tools.yml
@@ -22,6 +22,15 @@
       name: "{{ extra_tools }}"
       state: latest
 
+  - name: Tools | Install sphinx
+    apt:
+      name: "{{ item }}"
+      state: latest
+      force: yes
+    with_items:
+      - python-sphinx
+    when: enable_kohadocs
+
   - name: Tools | Stop memcached if required
     service:
       name: memcached

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -9,6 +9,7 @@ sync_repo: false
 skip_webinstaller: false
 create_admin_user: false
 enable_memcached: true
+enable_kohadocs: true
 elasticsearch: false
 elasticsearch_version: '5.x'
 plack: true
@@ -34,6 +35,9 @@ koha_pin_custom_repo: no
 
 koha_git_repo: http://git.koha-community.org/koha.git
 koha_git_branch: master
+
+kohadocs_git_repo: https://gitlab.com/koha-community-devs-users/kohadocs.git
+kohadocs_git_branch: master
 
 koha_instance_name: kohadev
 koha_domain: .myDNSname.org

--- a/vars/user.yml.sample
+++ b/vars/user.yml.sample
@@ -12,6 +12,7 @@
 # skip_webinstaller: false
 # create_admin_user: false
 # enable_memcached: true
+# enable_kohadocs: true
 # elasticsearch: false
 # elasticsearch_version: '5.x'
 # plack: true
@@ -37,6 +38,9 @@
 
 # koha_git_repo: http://git.koha-community.org/koha.git
 # koha_git_branch: master
+
+# kohadocs_git_repo: https://gitlab.com/koha-community-devs-users/kohadocs.git
+# kohadocs_git_branch: master
 
 # koha_instance_name: kohadev
 # koha_domain: .myDNSname.org


### PR DESCRIPTION
Adding the kohadocs repository and an enable_kohadocs boolean to vars/defaults.yml and vars/user.yml.sample along with a kohadocs-src.yml under ansible tasks enables automation of kohadocs when running vagrant up.

## Test Plan

1. Set `enable_kohadocs` in vars/user.yml to **true** and uncomment it
2. Uncomment `kohadocs_git_repo` and `kohadocs_git_branch`
3. Run `vagrant up` and Sphinx should be installed and have a kohadocs folder under /home/vagrant/
