### PR TITLE
Fixed SYNC_REPO functionality on Windows machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ order to be used. This is done like this:
 * **prove_debug**: Run the *prove* command with all parameters needed for starting
   a remote debugging session.
 
+Kohadevbox on Windows
+
+Running kohadevbox on Windows requires the use of a native Windows feature called
+Samba (usually written as its acronym "SMB" or "smb"). On Windows, after running
+`vagrant up` you will be prompted for your Windows username and password.
+
 ## Environment variables
 
 Some of the behaviour of KohaDevBox can be altered through the use of environment
@@ -239,6 +245,10 @@ the plugin is not present and SYNC_REPO is set, it will fail with an error.
 
    ```
    export SYNC_REPO="c:\\Users\\Me\\kohaclone\\"
+   ```
+* UPDATE: Windows also supports paths with forward slash so it's possible to use:
+   ```
+   export SYNC_REPO="c:/Users/Me/kohaclone/"
    ```
 
 ### SKIP_WEBINSTALLER

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ order to be used. This is done like this:
 * **prove_debug**: Run the *prove* command with all parameters needed for starting
   a remote debugging session.
 
-Kohadevbox on Windows
+## Kohadevbox on Windows
 
 Running kohadevbox on Windows requires the use of a native Windows feature called
 Samba (usually written as its acronym "SMB" or "smb"). On Windows, after running

--- a/README.md
+++ b/README.md
@@ -266,6 +266,20 @@ the plugin is not present and SYNC_REPO is set, it will fail with an error.
    export SYNC_REPO="c:/Users/Me/kohaclone/"
    ```
 
+### SMB
+
+Value: 1
+
+Usage:
+
+```
+  $ SMB=1 SYNC_REPO="/home/me/kohaclone" vagrant up
+```
+
+If you are running on Windows and you have administrative privileges on the computer
+and you wish to make use of the SYNC_REPO functionality, enable the SMB variable in
+order to use SYNC_REPO.
+
 ### SKIP_WEBINSTALLER
 
 Value: 1

--- a/README.md
+++ b/README.md
@@ -181,6 +181,21 @@ Running kohadevbox on Windows requires the use of a native Windows feature calle
 Samba (usually written as its acronym "SMB" or "smb"). On Windows, after running
 `vagrant up` you will be prompted for your Windows username and password.
 
+In order for SMB functionality to work on Vagrant, [PowerShell 5 is required](https://www.microsoft.com/en-us/download/details.aspx?id=50395).
+
+PowerShell's version can be checked with the following command after opening PowerShell:
+
+```
+  PS C:\> $PSVersionTable.PSVersion
+```
+
+### **Default PowerShell version by Windows version**
+
+* Windows 7   - PowerShell 2.0
+* Windows 8   - PowerShell 3.0
+* Windows 8.1 - PowerShell 4.0
+* Windows 10  - PowerShell 5.0
+
 ## Environment variables
 
 Some of the behaviour of KohaDevBox can be altered through the use of environment

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.hostname = "kohadevbox"
   if OS.windows?
-    config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+    config.vm.synced_folder ".", "/vagrant", type: "smb"
   end
 
   config.vm.define "stretch", autostart: false do |stretch|
@@ -103,7 +103,7 @@ Vagrant.configure(2) do |config|
         raise 'The vagrant-vbguest plugin is not present, and is mandatory for SYNC_REPO on Windows! See README.md'
       end
 
-      config.vm.synced_folder sync_repo_dir, vconfig['koha_dir'], type: "virtualbox"
+      config.vm.synced_folder sync_repo_dir, vconfig['koha_dir'], type: "smb"
 
     else
       # We should safely rely on NFS
@@ -117,7 +117,7 @@ Vagrant.configure(2) do |config|
         raise 'The vagrant-vbguest plugin is not present, and is mandatory for SYNC_KOHADOCS on Windows! See README.md'
       end
 
-      config.vm.synced_folder ENV['SYNC_KOHADOCS'], vconfig['kohadocs_dir'], type: "virtualbox"
+      config.vm.synced_folder ENV['SYNC_KOHADOCS'], vconfig['kohadocs_dir'], type: "smb"
 
     else
       # We should safely rely on NFS
@@ -134,7 +134,7 @@ Vagrant.configure(2) do |config|
         raise 'The vagrant-vbguest plugin is not present, and is mandatory for PLUGIN_REPO on Windows! See README.md'
       end
 
-      config.vm.synced_folder ENV['PLUGIN_REPO'], plugin_dir, type: "virtualbox"
+      config.vm.synced_folder ENV['PLUGIN_REPO'], plugin_dir, type: "smb"
 
     else
       # We should safely rely on NFS

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,11 @@ Vagrant.configure(2) do |config|
 
   config.vm.hostname = "kohadevbox"
   if OS.windows?
-    config.vm.synced_folder ".", "/vagrant", type: "smb"
+    if ENV['SMB']
+      config.vm.synced_folder ".", "/vagrant", type: "smb"
+    else
+      config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+    end
   end
 
   config.vm.define "stretch", autostart: false do |stretch|
@@ -102,8 +106,12 @@ Vagrant.configure(2) do |config|
       unless Vagrant.has_plugin?("vagrant-vbguest")
         raise 'The vagrant-vbguest plugin is not present, and is mandatory for SYNC_REPO on Windows! See README.md'
       end
-
-      config.vm.synced_folder sync_repo_dir, vconfig['koha_dir'], type: "smb"
+    
+      if ENV['SMB']
+        config.vm.synced_folder sync_repo_dir, vconfig['koha_dir'], type: "smb"
+      else
+        config.vm.synced_folder sync_repo_dir, vconfig['koha_dir'], type: "virtualbox"
+      end
 
     else
       # We should safely rely on NFS
@@ -117,7 +125,11 @@ Vagrant.configure(2) do |config|
         raise 'The vagrant-vbguest plugin is not present, and is mandatory for SYNC_KOHADOCS on Windows! See README.md'
       end
 
-      config.vm.synced_folder ENV['SYNC_KOHADOCS'], vconfig['kohadocs_dir'], type: "smb"
+      if ENV['SMB']
+        config.vm.synced_folder ENV['SYNC_KOHADOCS'], vconfig['kohadocs_dir'], type: "smb"
+      else
+        config.vm.synced_folder ENV['SYNC_KOHADOCS'], vconfig['kohadocs_dir'], type: "virtualbox"
+      end
 
     else
       # We should safely rely on NFS
@@ -134,7 +146,11 @@ Vagrant.configure(2) do |config|
         raise 'The vagrant-vbguest plugin is not present, and is mandatory for PLUGIN_REPO on Windows! See README.md'
       end
 
-      config.vm.synced_folder ENV['PLUGIN_REPO'], plugin_dir, type: "smb"
+      if ENV['SMB']
+        config.vm.synced_folder ENV['PLUGIN_REPO'], plugin_dir, type: "smb"
+      else
+        config.vm.synced_folder ENV['PLUGIN_REPO'], plugin_dir, type: "virtualbox"
+      end
 
     else
       # We should safely rely on NFS


### PR DESCRIPTION
Changed the type: "virtualbox" to type: "smb" to enable native Windows folder support for all SYNC_REPO commands and updated the README to reflect the Windows-only changes.