### PR TITLE
Script to take new users through setting up Kohadevbox gitbz configs

### DIFF
--- a/configurebzconfigs.sh
+++ b/configurebzconfigs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Koha git-bz configuration setting script"
+git config bz.default-tracker bugs.koha-community.org
+git config bz.default-product Koha
+git config --global bz-tracker.bugs.koha-community.org.path /bugzilla3
+git config --global bz-tracker.bugs.koha-community.org.https true
+git config --global core.whitespace trailing-space,space-before-tab
+git config --global apply.whitespace fix
+
+read -p "Enter your Koha Bugzilla username: " username
+git config --global bz-tracker.bugs.koha-community.org.bz-user $username
+
+read -p "Enter your Bugzilla password: " password
+git config --global bz-tracker.bugs.koha-community.org.bz-password $password
+
+          


### PR DESCRIPTION
To resolve issue #257

This script goes through the steps outlined
here: https://wiki.koha-community.org/wiki/Git_bz_configuration

In addition to setting the default tracker, default-product,
bug.koha-community,org path, it also queries the user to write in their
username and password.

Running this script after setting up kohadevbox would be useful for new,
inexperienced users as they can set the git-bz configs fast and have
less chance of mistakes which could be made if they were copying and
pasting in the commands from the wiki page.

This also allows multiple users to use the same kohadevbox and quickly
set their individual bugzilla credentials.

Test plan:
 1. Run the command: ./setbzconfigs.sh

 2. Enter your Bugzilla username and password

 3. Run the command: git config --list and notice the credentials you
 wrote when running the aforementioned script are set as global git
 configs

Sponsored-By: Catalyst IT